### PR TITLE
Stream dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ meilisearch-core/target
 /*.mdb
 /query-history.txt
 /data.ms
+/dumps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-multipart"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774bfeb11b54bf9c857a005b8ab893293da4eaff79261a66a9200dab7f5ab6e3"
+dependencies = [
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "bytes 0.5.6",
+ "derive_more",
+ "futures-util",
+ "httparse",
+ "log",
+ "mime",
+ "twoway",
+]
+
+[[package]]
 name = "actix-router"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1636,7 @@ version = "0.15.0"
 dependencies = [
  "actix-cors",
  "actix-http",
+ "actix-multipart",
  "actix-rt",
  "actix-service",
  "actix-web",
@@ -1643,6 +1662,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "rustls 0.18.1",
+ "sanitize-filename",
  "sentry",
  "serde",
  "serde_json",
@@ -2379,6 +2399,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sanitize-filename"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fd0fec94ec480abfd86bb8f4f6c57e0efb36dac5c852add176ea7b04c74801"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,6 +3066,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "twoway"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b40075910de3a912adbd80b5d8bad6ad10a23eeb1f5bf9d4006839e899ba5bc"
+dependencies = [
+ "memchr",
+ "unchecked-index",
+]
+
+[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3055,6 +3095,12 @@ checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "unchecked-index"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,27 +343,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 
 [[package]]
-name = "async-stream"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
-dependencies = [
- "async-stream-impl",
- "futures-core",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,7 +1622,6 @@ dependencies = [
  "actix-service",
  "actix-web",
  "assert-json-diff",
- "async-stream",
  "bytes 0.5.6",
  "chrono",
  "crossbeam-channel",
@@ -1661,6 +1639,7 @@ dependencies = [
  "meilisearch-tokenizer",
  "mime",
  "once_cell",
+ "pin-utils",
  "rand 0.7.3",
  "regex",
  "rustls 0.18.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 
 [[package]]
+name = "async-stream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +1643,7 @@ dependencies = [
  "actix-service",
  "actix-web",
  "assert-json-diff",
+ "async-stream",
  "bytes 0.5.6",
  "chrono",
  "crossbeam-channel",
@@ -1914,7 +1936,8 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 [[package]]
 name = "pest"
 version = "2.1.3"
-source = "git+https://github.com/pest-parser/pest.git?rev=51fd1d49f1041f7839975664ef71fe15c7dcaf67#51fd1d49f1041f7839975664ef71fe15c7dcaf67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
 ]
@@ -1922,8 +1945,7 @@ dependencies = [
 [[package]]
 name = "pest"
 version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+source = "git+https://github.com/pest-parser/pest.git?rev=51fd1d49f1041f7839975664ef71fe15c7dcaf67#51fd1d49f1041f7839975664ef71fe15c7dcaf67"
 dependencies = [
  "ucd-trie",
 ]

--- a/meilisearch-error/src/lib.rs
+++ b/meilisearch-error/src/lib.rs
@@ -79,6 +79,7 @@ pub enum Code {
 
     DumpAlreadyInProgress,
     DumpProcessFailed,
+    DumpReadFailed,
 }
 
 impl Code {
@@ -129,6 +130,7 @@ impl Code {
             // error related to dump
             DumpAlreadyInProgress => ErrCode::invalid("dump_already_in_progress", StatusCode::CONFLICT),
             DumpProcessFailed => ErrCode::internal("dump_process_failed", StatusCode::INTERNAL_SERVER_ERROR),
+            DumpReadFailed => ErrCode::internal("dump_read_failed", StatusCode::INTERNAL_SERVER_ERROR),
         }
     }
 

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -22,7 +22,6 @@ actix-http = "2"
 actix-rt = "1"
 actix-service = "1.0.6"
 actix-web = { version = "3", features = ["rustls"] }
-async-stream = "0.3.0"
 bytes = "0.5.4"
 chrono = { version = "0.4.11", features = ["serde"] }
 crossbeam-channel = "0.4.2"
@@ -39,6 +38,7 @@ meilisearch-schema = { path = "../meilisearch-schema", version = "0.15.0" }
 meilisearch-tokenizer = {path = "../meilisearch-tokenizer", version = "0.15.0"}
 mime = "0.3.16"
 once_cell = "1.4.1"
+pin-utils = "0.1"
 rand = "0.7.3"
 regex = "1.3.6"
 rustls = "0.18"

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -22,6 +22,7 @@ actix-http = "2"
 actix-rt = "1"
 actix-service = "1.0.6"
 actix-web = { version = "3", features = ["rustls"] }
+async-stream = "0.3.0"
 bytes = "0.5.4"
 chrono = { version = "0.4.11", features = ["serde"] }
 crossbeam-channel = "0.4.2"
@@ -50,7 +51,7 @@ slice-group-by = "0.2.6"
 structopt = "0.3.12"
 tar = "0.4.29"
 tempfile = "3.1.0"
-tokio = { version = "0.2.18", features = ["macros"] }
+tokio = { version = "0.2.18", features = ["macros", "fs", "stream"] }
 ureq = { version = "0.12.0", features = ["tls"], default-features = false }
 walkdir = "2.3.1"
 whoami = "0.8.1"

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -19,6 +19,7 @@ default = ["sentry"]
 [dependencies]
 actix-cors = "0.3"
 actix-http = "2"
+actix-multipart = "0.3.0"
 actix-rt = "1"
 actix-service = "1.0.6"
 actix-web = { version = "3", features = ["rustls"] }
@@ -42,6 +43,7 @@ pin-utils = "0.1"
 rand = "0.7.3"
 regex = "1.3.6"
 rustls = "0.18"
+sanitize-filename = "0.2.1"
 serde = { version = "1.0.105", features = ["derive"] }
 serde_json = { version = "1.0.50", features = ["preserve_order"] }
 serde_qs = "0.5.2"

--- a/meilisearch-http/src/error.rs
+++ b/meilisearch-http/src/error.rs
@@ -55,6 +55,7 @@ pub enum Error {
     UnsupportedMediaType,
     DumpAlreadyInProgress,
     DumpProcessFailed,
+    DumpReadFailed(String),
 }
 
 impl error::Error for Error {}
@@ -82,6 +83,7 @@ impl ErrorCode for Error {
             UnsupportedMediaType => Code::UnsupportedMediaType,
             DumpAlreadyInProgress => Code::DumpAlreadyInProgress,
             DumpProcessFailed => Code::DumpProcessFailed,
+            DumpReadFailed(_) => Code::DumpReadFailed,
         }
     }
 }
@@ -192,6 +194,11 @@ impl Error {
     pub fn dump_failed() -> Error {
         Error::DumpProcessFailed
     }
+
+    pub fn dump_read_failed(err: impl fmt::Display) -> Error {
+        Error::DumpReadFailed(err.to_string())
+    }
+
 }
 
 impl fmt::Display for Error {
@@ -216,6 +223,7 @@ impl fmt::Display for Error {
             Self::UnsupportedMediaType => f.write_str("Unsupported media type"),
             Self::DumpAlreadyInProgress => f.write_str("Another dump is already in progress"),
             Self::DumpProcessFailed => f.write_str("Dump process failed"),
+            Self::DumpReadFailed(err) => write!(f, "Dump read failed; {}", err),
         }
     }
 }

--- a/meilisearch-http/src/routes/dump.rs
+++ b/meilisearch-http/src/routes/dump.rs
@@ -90,9 +90,9 @@ impl tokio::stream::Stream for StreamBody {
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         //  you can't hold to mut refs to self, need to take ownership on the buffer for some time
-        let mut buffer = std::mem::replace(&mut self.buffer, vec![]);
-        let file = &mut self.file;
-        pin_utils::pin_mut!(file);
+        let chunk_size = self.buffer.len();
+        let mut buffer = std::mem::replace(&mut self.buffer, vec![0u8; chunk_size]);
+        let file = Pin::new(&mut self.file);
         match file.poll_read(cx, &mut buffer) {
             Poll::Ready(Ok(size)) => {
                 if size > 0 {

--- a/meilisearch-http/src/routes/dump.rs
+++ b/meilisearch-http/src/routes/dump.rs
@@ -2,12 +2,13 @@ use std::fs::File;
 use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::io::{BufReader, Read};
 use bytes::Bytes;
 
 use actix_web::{get, post};
 use actix_web::{HttpResponse, web};
 use serde::{Deserialize, Serialize};
+use tokio::io::AsyncReadExt;
+use async_stream::stream;
 
 use crate::dump::{DumpInfo, DumpStatus, compressed_dumps_folder, init_dump_process};
 use crate::Data;
@@ -17,7 +18,7 @@ use crate::helpers::Authentication;
 pub fn services(cfg: &mut web::ServiceConfig) {
     cfg.service(trigger_dump)
         .service(get_dump_status)
-        .service(stream_dump);
+        .service(download_dump);
 }
 
 #[post("/dumps", wrap = "Authentication::Private")]
@@ -69,22 +70,21 @@ async fn get_dump_status(
 }
 
 struct StreamBody {
-    reader: BufReader<File>,
+    file: tokio::fs::File,
     buffer: Vec<u8>,
 }
 
 impl StreamBody {
-    fn new(file: File, chunk_size: usize) -> Self {
-        let reader = BufReader::new(file);
+    fn new(file: tokio::fs::File, chunk_size: usize) -> Self {
         let buffer = vec![0u8; chunk_size];
         StreamBody {
-            reader,
+            file,
             buffer,
         }
     }
 }
 
-impl futures::stream::Stream for StreamBody {
+impl tokio::stream::Stream for StreamBody {
     type Item = Result<Bytes, ResponseError>;
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -92,28 +92,29 @@ impl futures::stream::Stream for StreamBody {
     ) -> Poll<Option<Self::Item>> {
         use std::ops::DerefMut;
         let stream = self.deref_mut();
-        match stream.reader.read(&mut stream.buffer) {
-            Ok(count) => {
-                if count > 0 {
-                    Poll::Ready(Some(Ok(Bytes::copy_from_slice(&self.buffer[..count]))))
-                } else {
-                    Poll::Ready(None)
-                }
-            },
-            Err(e) => Poll::Ready(Some(Err(Error::dump_read_failed(e).into())))
-        }
+            match stream.file.read(&mut stream.buffer).await {
+                Ok(count) => {
+                    if count > 0 {
+                        Poll::Ready(Some(Ok(Bytes::copy_from_slice(&self.buffer[..count]))))
+                    } else {
+                        Poll::Ready(None)
+                    }
+                },
+                Err(e) => Poll::Ready(Some(Err(Error::dump_read_failed(e).into())))
+            }
     }
 }
 
 #[get("/dumps/{dump_uid}", wrap = "Authentication::Private")]
-async fn stream_dump(
+async fn download_dump(
     data: web::Data<Data>,
     path: web::Path<DumpParam>,
 ) -> Result<HttpResponse, ResponseError> {
     let dumps_folder = Path::new(&data.dumps_folder);
     let dump_uid = &path.dump_uid;
+    let path = compressed_dumps_folder(Path::new(dumps_folder), dump_uid);
 
-    match File::open(compressed_dumps_folder(Path::new(dumps_folder), dump_uid)) {
+    match tokio::fs::File::open(path).await {
         Ok(file) => Ok(HttpResponse::Ok().streaming(StreamBody::new(file, 1024))),
         Err(_) => Err(Error::not_found("dump does not exist").into())
     }

--- a/meilisearch-http/src/routes/dump.rs
+++ b/meilisearch-http/src/routes/dump.rs
@@ -92,20 +92,15 @@ impl tokio::stream::Stream for StreamBody {
     ) -> Poll<Option<Self::Item>> {
         //  you can't hold to mut refs to self, need to take ownership on the buffer for some time
         let mut buffer = std::mem::replace(&mut self.buffer, vec![]);
-        println!("std::mem::replace");
         let file = &mut self.file;
         pin_utils::pin_mut!(file);
-        println!("pin_mut");
         match file.poll_read(cx, &mut buffer) {
             Poll::Ready(Ok(size)) => {
                 if size > 0 {
-                    println!("poll_read {}", size);
                     // place it back when done with it
                     let _ = std::mem::replace(&mut self.buffer, buffer);
-                    println!("poll_read2 {}", size);
                     Poll::Ready(Some(Ok(Bytes::copy_from_slice(&self.buffer[..size]))))
                 } else {
-                    println!("poll_read fail {}", size);
                     Poll::Ready(None)
                 }
             }

--- a/meilisearch-http/src/routes/dump.rs
+++ b/meilisearch-http/src/routes/dump.rs
@@ -76,7 +76,6 @@ struct StreamBody {
 impl StreamBody {
     fn new(file: tokio::fs::File, chunk_size: usize) -> Self {
         let buffer = vec![0u8; chunk_size];
-        println!("buffer!!!!");
         StreamBody {
             file,
             buffer,
@@ -118,8 +117,6 @@ async fn download_dump(
     let dumps_folder = Path::new(&data.dumps_folder);
     let dump_uid = &path.dump_uid;
     let path = compressed_dumps_folder(Path::new(dumps_folder), dump_uid);
-
-    println!("download_dump");
 
     match tokio::fs::File::open(path).await {
         Ok(file) => Ok(HttpResponse::Ok().streaming(StreamBody::new(file, 1024))),

--- a/meilisearch-http/src/routes/dump.rs
+++ b/meilisearch-http/src/routes/dump.rs
@@ -75,6 +75,7 @@ struct StreamBody {
 }
 
 impl StreamBody {
+
     fn new(file: tokio::fs::File, chunk_size: usize) -> Self {
         let buffer = vec![0u8; chunk_size];
         StreamBody {
@@ -82,6 +83,9 @@ impl StreamBody {
             buffer,
         }
     }
+
+    
+
 }
 
 impl tokio::stream::Stream for StreamBody {
@@ -92,16 +96,16 @@ impl tokio::stream::Stream for StreamBody {
     ) -> Poll<Option<Self::Item>> {
         use std::ops::DerefMut;
         let stream = self.deref_mut();
-            match stream.file.read(&mut stream.buffer).await {
-                Ok(count) => {
-                    if count > 0 {
-                        Poll::Ready(Some(Ok(Bytes::copy_from_slice(&self.buffer[..count]))))
-                    } else {
-                        Poll::Ready(None)
-                    }
-                },
-                Err(e) => Poll::Ready(Some(Err(Error::dump_read_failed(e).into())))
-            }
+        match stream.file.read(&mut stream.buffer).await {
+            Ok(count) => {
+                if count > 0 {
+                    Poll::Ready(Some(Ok(Bytes::copy_from_slice(&self.buffer[..count]))))
+                } else {
+                    Poll::Ready(None)
+                }
+            },
+            Err(e) => Poll::Ready(Some(Err(Error::dump_read_failed(e).into())))
+        }
     }
 }
 

--- a/meilisearch-http/tests/common.rs
+++ b/meilisearch-http/tests/common.rs
@@ -519,7 +519,7 @@ impl Server {
         self.get_request(&url).await
     }
 
-    pub async fn fetch_dump(&mut self, dump_uid: &str) -> (Bytes, StatusCode) {
+    pub async fn download_dump(&mut self, dump_uid: &str) -> (Bytes, StatusCode) {
         let url = format!("/dumps/{}", dump_uid);
         self.get_bytes_request(&url).await
     }

--- a/meilisearch-http/tests/dump.rs
+++ b/meilisearch-http/tests/dump.rs
@@ -364,7 +364,7 @@ async fn get_unexisting_dump_status_should_return_not_found() {
 
 #[actix_rt::test]
 #[ignore]
-async fn stream_dump_should_return_processed_file() {
+async fn download_dump_should_return_processed_file() {
     let mut server = common::Server::test_server().await;
 
     let dataset = include_bytes!("assets/dumps/v1/test/documents.jsonl");
@@ -374,7 +374,7 @@ async fn stream_dump_should_return_processed_file() {
 
     let uid = trigger_and_wait_dump(&mut server).await;
 
-    let (bytes, status_code) = server.fetch_dump(&uid).await;
+    let (bytes, status_code) = server.download_dump(&uid).await;
 
     assert_eq!(status_code, 200);
 


### PR DESCRIPTION
# Description

Add a route that allows the download of a dump stored in the server. This function is interesting when using the server in conjunction with the official SDKs and other tools. This allows the manager to fetch the document by simply calling the endpoint.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist

- [X] Implement the fetch dump route
- [X] Write unit test
- [ ] Stress test (large file)
- [ ] Update documentation
- [ ] Update changelog 